### PR TITLE
Auto-config & timeout feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [CtrlP][1] extension for global searching source code with ag.
 Modified from [vim-ctrlp-tjump][2], another CtrlP extension that is strongly recommended.
 
+Automatically configures `:grep` and CtrlP to use ag unless `grepprg` or `g:ctrlp_user_command`
+have been user-defined.
+
 ## Installation
 
 1. Fire any plugin manager like Vundle

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CtrlP ag
 
 [CtrlP][1] extension for global searching source code with ag.
-Modified from [vim-ctrlp-tjump][2], another CtrlP extension that strongly recommanded.
+Modified from [vim-ctrlp-tjump][2], another CtrlP extension that is strongly recommended.
 
 ## Installation
 
@@ -26,6 +26,14 @@ Modified from [vim-ctrlp-tjump][2], another CtrlP extension that strongly recomm
 - Press `<leader>ca`, a prompt opened to ask you what to search
 - Press `<leader>cp`, to redo the last ag search in CtrlP
 
+## Configuration
+
+- Set the variable `g:ctrlp_ag_filter` to a command that executes its arguments as a sub-command,
+  which in turn allows filtering the results. (Default: `'timeout 10'` or `'gtimeout 10'` or
+  undefined, depending on the programs you've installed)
+- Set the variable `g:ctrlp_ag_timeout` to the number of seconds that the timeout filter should wait
+  for ag to complete. (Default: `10`) Don't touch `g:ctrlp_ag_filter` if you want to use this
+  filter.
 
 [1]: https://github.com/kien/ctrlp.vim
 [2]: https://github.com/ivalkeen/vim-ctrlp-tjump

--- a/autoload/ctrlp/ag.vim
+++ b/autoload/ctrlp/ag.vim
@@ -35,7 +35,7 @@ function! ctrlp#ag#exec(mode)
     let s:word = a:mode
   endif
 
-  let s:ag_results = split(system("ag -Qs --column --ignore tags '" . s:word . "'"), "\n")
+  let s:ag_results = split(system(g:ctrlp_ag_filter . "ag -Qs --column --ignore tags '" . s:word . "'"), "\n")
 
   " remove current file/line from results
   let bname = bufname('%') . ':' . line('.')

--- a/plugin/ag.vim
+++ b/plugin/ag.vim
@@ -4,23 +4,31 @@ command! -range CtrlPagVisual <line1>,<line2>call ctrlp#ag#exec('v')
 command! -nargs=1 CtrlPagLocate call ctrlp#ag#exec(<q-args>)
 
 if exists('g:ctrlp_ag_filter')
-  let g:ctrlp_ag_filter .= ' '
+	let g:ctrlp_ag_filter .= ' '
 else
-  if !exists('g:ctrlp_ag_timeout')
-    let g:ctrlp_ag_timeout = 10
-  endif
-  if executable('timeout')
-    let g:ctrlp_ag_filter = 'timeout ' . g:ctrlp_ag_timeout . ' '
-  elseif executable('gtimeout')
-    let g:ctrlp_ag_filter = 'gtimeout ' . g:ctrlp_ag_timeout . ' '
-  else
-    let g:ctrlp_ag_filter = ''
-  endif
+	if !exists('g:ctrlp_ag_timeout')
+		let g:ctrlp_ag_timeout = 10
+	endif
+	if executable('timeout')
+		let g:ctrlp_ag_filter = 'timeout ' . g:ctrlp_ag_timeout . ' '
+	elseif executable('gtimeout')
+		let g:ctrlp_ag_filter = 'gtimeout ' . g:ctrlp_ag_timeout . ' '
+	else
+		let g:ctrlp_ag_filter = ''
+	endif
 endif
 
-if executable('ag') && !exists('g:ctrlp_user_command')
-  set grepformat=%f:%l:%c:%m
+if executable('ag')
+	let prg = &grepprg
+	set grepprg&
+	if prg ==# &grepprg
+		set grepformat=%f:%l:%c:%m
+		let &grepprg = g:ctrlp_ag_filter . 'ag --vimgrep --hidden $*'
+	else
+		let &grepprg = prg
+	endif
 
-  let &grepprg = g:ctrlp_ag_filter . 'ag --vimgrep --hidden $*'
-  let g:ctrlp_user_command = g:ctrlp_ag_filter . 'ag %s --nocolor --nogroup --hidden -g ""'
+	if !exists('g:ctrlp_user_command')
+		let g:ctrlp_user_command = g:ctrlp_ag_filter . 'ag %s --nocolor --nogroup --hidden -g ""'
+	endif
 endif

--- a/plugin/ag.vim
+++ b/plugin/ag.vim
@@ -2,3 +2,25 @@ command! CtrlPag call ctrlp#ag#exec('n')
 command! CtrlPagPrevious call ctrlp#ag#exec('p')
 command! -range CtrlPagVisual <line1>,<line2>call ctrlp#ag#exec('v')
 command! -nargs=1 CtrlPagLocate call ctrlp#ag#exec(<q-args>)
+
+if exists('g:ctrlp_ag_filter')
+  let g:ctrlp_ag_filter .= ' '
+else
+  if !exists('g:ctrlp_ag_timeout')
+    let g:ctrlp_ag_timeout = 10
+  endif
+  if executable('timeout')
+    let g:ctrlp_ag_filter = 'timeout ' . g:ctrlp_ag_timeout . ' '
+  elseif executable('gtimeout')
+    let g:ctrlp_ag_filter = 'gtimeout ' . g:ctrlp_ag_timeout . ' '
+  else
+    let g:ctrlp_ag_filter = ''
+  endif
+endif
+
+if executable('ag') && !exists('g:ctrlp_user_command')
+  set grepformat=%f:%l:%c:%m
+
+  let &grepprg = g:ctrlp_ag_filter . 'ag --vimgrep --hidden $*'
+  let g:ctrlp_user_command = g:ctrlp_ag_filter . 'ag %s --nocolor --nogroup --hidden -g ""'
+endif


### PR DESCRIPTION
This PR adds two features that were necessary for me:
- The plugin now automatically configures Vim’s grep command and CtrlP (g:ctrlp_user_command) to use ag, unless these settings have been overwritten by the user.
- If either the timeout or gtimeout program is installed, it will be used to execute the ag command instead of invoking it directly, in order to prevent Vim from being frozen for a long period if ag is invoked in a directory with a huge amount of files (e.g. home or root). This is configurable (before the plugin is loaded).