### PR TITLE
Renames ctrlp_ag_ignores to ctrlp_ag_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ have been user-defined.
     vnoremap <c-f> :CtrlPagVisual<cr>
     nnoremap <leader>ca :CtrlPagLocate
     nnoremap <leader>cp :CtrlPagPrevious<cr>
-    let g:ctrlp_ag_ignores = '--ignore .git
+    let g:ctrlp_ag_options = '--ignore .git
         \ --ignore "deps/*"
         \ --ignore "_build/*"
         \ --ignore "node_modules/*"'

--- a/autoload/ctrlp/ag.vim
+++ b/autoload/ctrlp/ag.vim
@@ -49,8 +49,8 @@ function! ctrlp#ag#exec(mode)
     endif
   endif
 
-  if (!exists('g:ctrlp_ag_ignores'))
-    let g:ctrlp_ag_ignores = "--ignore tags"
+  if (!exists('g:ctrlp_ag_options'))
+    let g:ctrlp_ag_options = "--ignore tags"
   endif
 
   if exists('g:ctrlp_ag_search_base') 
@@ -65,7 +65,7 @@ function! ctrlp#ag#exec(mode)
 
   let s:ag_results = split(system(g:ctrlp_ag_filter .
         \ "ag -Q " . s:ag_opt_for_sensitivity .
-        \ " --column " . g:ctrlp_ag_ignores .
+        \ " --column " . g:ctrlp_ag_options .
         \ " '" . s:word . "' " . dir . ""), "\n")
 
   " remove current file/line from results


### PR DESCRIPTION
I needed to add the `--hidden` option to `ag` but couldn't find a way to do so. Until I realized that I could use the `ctrlp_ag_ignores` variable to do that.